### PR TITLE
Corrections du contrôleur TAT

### DIFF
--- a/app/controllers/tat_controller.rb
+++ b/app/controllers/tat_controller.rb
@@ -25,9 +25,6 @@ class TatController < ApplicationController
       @tat.save!
       session[:key] = @tat.id
     end
-    # Obligée d'ajouter "if params[:session]" >> sinon erreur
-    session[:hiddenText] = params[:session][:hiddenText] if params[:session]
-    session[:errorMargin] = params[:session][:errorMargin] if params[:session]
     #Reroute vers les différentes méthodes en fonctions des données envoyées par l'utilisateur
     if params[:session] && !params[:session][:inputFile].nil?
       @tat.step = "file"
@@ -43,6 +40,8 @@ class TatController < ApplicationController
       @tat.save!
     elsif params[:session] && !params[:session][:inputText].nil? && params[:session][:inputText] != "" && @tat.step == "file"
       @tat.fullText = params[:session][:inputText]
+      session[:hiddenText] = params[:session][:hiddenText]
+      session[:errorMargin] = params[:session][:errorMargin]
       @tat.step = "tat"
       @tat.save!
       tatGeneration

--- a/app/controllers/tat_controller.rb
+++ b/app/controllers/tat_controller.rb
@@ -37,12 +37,16 @@ class TatController < ApplicationController
       @tat.step = "answers"
       @tat.save!
       tatVerify
-    elsif params[:session] && !params[:session][:inputText].nil? && params[:session][:inputText] != ""
-	  @tat.fullText = params[:session][:inputText]
-	  @tat.step = "tat"
+    elsif params[:session] && !params[:session][:inputText].nil? && params[:session][:inputText] != "" && @tat.step == "init"
+      @tat.fullText = params[:session][:inputText]
+      @tat.step = "file"
+      @tat.save!
+    elsif params[:session] && !params[:session][:inputText].nil? && params[:session][:inputText] != "" && @tat.step == "file"
+      @tat.fullText = params[:session][:inputText]
+      @tat.step = "tat"
       @tat.save!
       tatGeneration
-	else
+    else
       @tat.step = "init"
       @tat.save!
     end
@@ -75,28 +79,28 @@ class TatController < ApplicationController
     if (!array_tat.nil?)
       @tat.tat_content = array_tat[0].join(session[:splitter])
       @tat.tat_answers = array_tat[1].join(session[:splitter])
-	else
+    else
       @tat.step = "init"
     end
-	@tat.save!
+    @tat.save!
   end
 
   def tatVerify
     #Vérifie les réponses du texte à trous et stocke la correction dans un objet temporaire pour le front-end
     require 'core/tatnlp.rb'
-	if (@tat.tat_answers.nil?)
-		@tat.step = "answers is null"
-	else
-		tat_answers = @tat.tat_answers.split (session[:splitter])
-		user_answers = Array.new
-		j = tat_answers.count
-		for i in 1..j
-			user_answers.push params[:session][i.to_s]
-		end
-		array_isRight = TATNLP.verifyAnswers(tat_answers, user_answers, session[:errorMargin])
-		@tat.user_answers = user_answers.join(session[:splitter])
-		@tat.is_right = array_isRight.join(session[:splitter])
-	end
-	@tat.save!
+    if (@tat.tat_answers.nil?)
+      @tat.step = "answers is null"
+    else
+      tat_answers = @tat.tat_answers.split (session[:splitter])
+      user_answers = Array.new
+      j = tat_answers.count
+      for i in 1..j
+	user_answers.push params[:session][i.to_s]
+      end
+      array_isRight = TATNLP.verifyAnswers(tat_answers, user_answers, session[:errorMargin])
+      @tat.user_answers = user_answers.join(session[:splitter])
+      @tat.is_right = array_isRight.join(session[:splitter])
+    end
+    @tat.save!
   end
 end


### PR DESCRIPTION
- Pas de marge d'erreur ou de portion du texte masqué en cas d'entrée manuelle du texte.
- La marge d'erreur n'était pas prise en compte pour la correction, le résultat renvoyé restait à "False".
